### PR TITLE
add proper sign-conversions to avoid compiler-warnings

### DIFF
--- a/board_info.c
+++ b/board_info.c
@@ -48,6 +48,7 @@ static unsigned get_dt_ranges(const char *filename, unsigned offset)
          address = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
       fclose(fp);
    }
+
    return address;
 }
 
@@ -57,7 +58,7 @@ uint32_t board_info_peripheral_base_addr(void)
 
    board_info_init();
 
-   if (address == ~0)
+   if (address == (unsigned) ~0)
    {
       if (board_model == MODEL_B_2)
          return 0x3f000000;
@@ -76,7 +77,7 @@ uint32_t board_info_sdram_address(void)
 
    board_info_init();
 
-   if (address == ~0)
+   if (address == (unsigned)~0)
    {
       if (board_model == MODEL_B_2)
          return 0xc0000000;

--- a/dma.c
+++ b/dma.c
@@ -43,7 +43,7 @@
 
 
 // DMA address mapping by DMA number index
-const static uint32_t dma_offset[] =
+static const uint32_t dma_offset[] =
 {
     DMA0_OFFSET,
     DMA1_OFFSET,

--- a/mailbox.c
+++ b/mailbox.c
@@ -135,7 +135,7 @@ unsigned mem_alloc(int file_desc, unsigned size, unsigned align, unsigned flags)
    p[0] = i*sizeof *p; // actual size
 
    if (mbox_property(file_desc, p) < 0)
-      return -1;
+      return (unsigned) ~0;
    else
       return p[5];
 }
@@ -175,7 +175,7 @@ unsigned mem_lock(int file_desc, unsigned handle)
    p[0] = i*sizeof *p; // actual size
 
    if (mbox_property(file_desc, p) < 0)
-      return ~0;
+      return (unsigned) ~0;
    else
       return p[5];
 }

--- a/ws2811.c
+++ b/ws2811.c
@@ -488,12 +488,12 @@ int ws2811_init(ws2811_t *ws2811)
     mbox.handle = -1; // mbox_open();
     mbox.mem_ref = mem_alloc(mbox.handle, mbox.size, PAGE_SIZE,
             board_info_sdram_address() == 0x40000000 ? 0xC : 0x4);
-    if (mbox.mem_ref < 0)
+    if (mbox.mem_ref == (unsigned) ~0)
     {
        return -1;
     }
     mbox.bus_addr = mem_lock(mbox.handle, mbox.mem_ref);
-    if (mbox.bus_addr == ~0)
+    if (mbox.bus_addr == (unsigned) ~0)
     {
        mem_free(mbox.handle, mbox.size);
        return -1;
@@ -632,7 +632,7 @@ int ws2811_render(ws2811_t *ws2811)
                 (((channel->leds[i] >> 0)  & 0xff) * scale) >> 8, // blue
             };
 
-            for (j = 0; j < ARRAY_SIZE(color); j++)        // Color
+            for (j = 0; j < (int) ARRAY_SIZE(color); j++)        // Color
             {
                 for (k = 7; k >= 0; k--)                   // Bit
                 {


### PR DESCRIPTION
fixes compiler-warnings that appear when build with node-gyp, mostly about signed/unsigned comparisons.
