### PR TITLE
add support for rpi4

### DIFF
--- a/board_info.c
+++ b/board_info.c
@@ -11,6 +11,11 @@
 
 #include "board_info.h"
 
+// jimbotel: move OSC_FREQ here from ws2811.c as this board-dependent
+#define OSC_FREQ                                 19200000   // crystal frequency
+#define OSC_FREQ_2711                            54000000   // raspberry Pi 4B uses BCM2711 Crystal 19.2->54M
+
+// jimbotel: add model 4B
 enum
 {
    MODEL_UNKNOWN,
@@ -19,6 +24,7 @@ enum
    MODEL_B,
    MODEL_B_PLUS,
    MODEL_B_2,
+   MODEL_4B,
 };
 
 static int board_info_initialised = 0;
@@ -29,11 +35,28 @@ static void
 fatal(char *fmt, ...)
 {
    va_list ap;
-   
+
    va_start(ap, fmt);
    vfprintf(stderr, fmt, ap);
    va_end(ap);
    exit(1);
+}
+
+// jimbotel: add get_osc_freq function to obtain osc_freq of the board
+uint32_t get_osc_freq(void)
+{
+   uint32_t osc_freq;
+   board_info_init();
+
+   if(board_info_initialised == 0)
+      return -1;
+
+   if(board_model ==  MODEL_4B)
+        osc_freq = OSC_FREQ_2711;
+    else
+        osc_freq = OSC_FREQ;
+
+   return osc_freq;
 }
 
 static unsigned get_dt_ranges(const char *filename, unsigned offset)
@@ -58,10 +81,20 @@ uint32_t board_info_peripheral_base_addr(void)
 
    board_info_init();
 
+   // jimbotel: in the pi4, the address obtained is 0.
+   if (address == 0)
+   {
+      if (board_model == MODEL_4B)
+         return 0xFE000000;
+   }
+
    if (address == (unsigned) ~0)
    {
       if (board_model == MODEL_B_2)
          return 0x3f000000;
+      // jimbotel: I also added here just in case, however I haven't seen address being all 1s
+      else if (board_model == MODEL_4B)
+         return 0xFE000000;
       else
          return 0x20000000;
    }
@@ -79,7 +112,8 @@ uint32_t board_info_sdram_address(void)
 
    if (address == (unsigned)~0)
    {
-      if (board_model == MODEL_B_2)
+      // jimbotel: Pi4 shares the same sdram address as previous generation
+      if (board_model == MODEL_B_2 || board_model == MODEL_4B)
          return 0xc0000000;
       else
          return 0x40000000;
@@ -128,8 +162,15 @@ int board_info_init(void)
 
    ptr = revstr + strlen(revstr) - 3;
    board_revision = strtol(ptr, &end, 16);
+
+   // jimbotel: according to https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md , last two digits of revision = 17 (hex 11) for Pi4
+   // jimbotel: board_revision will become 2 a few lines below. Not sure why board_revision is finally set to either 1 or 2, I just didn't want to change previous behavior.
+   if (board_revision == 17)
+      board_model = MODEL_4B;
+
    if (end != ptr + 2)
       fatal("Failed to parse Revision string\n");
+
    if (board_revision < 1)
       fatal("Invalid board Revision\n");
    else if (board_revision < 4)

--- a/board_info.h
+++ b/board_info.h
@@ -3,4 +3,5 @@
 extern int board_info_init(void);
 extern uint32_t board_info_peripheral_base_addr(void);
 extern uint32_t board_info_sdram_address(void);
-
+// jimbotel: externalize the new function 
+extern uint32_t get_osc_freq(void);

--- a/mailbox.c
+++ b/mailbox.c
@@ -37,6 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+// jimbotel: include sys/sysmacros.h as gcc was complaining about makedev not defined
+#include <sys/sysmacros.h>
 
 #include "mailbox.h"
 

--- a/main.c
+++ b/main.c
@@ -51,6 +51,8 @@
 
 #define TARGET_FREQ                              WS2811_TARGET_FREQ
 #define GPIO_PIN                                 18
+// jimbotel: Note: we should avoid DMA channel 5 on raspberry pi according to https://github.com/beyondscreen/node-rpi-ws281x-native/issues/90#61
+// jimbotel: pigpio module defines PI_DEFAULT_DMA_PRIMARY_CHANNEL = 14 for the Pi3 and below (7 for the Pi4), and PI_DEFAULT_DMA_SECONDARY_CHANNEL = 6 in all cases.
 #define DMA                                      5
 
 #define WIDTH                                    3

--- a/ws2811.c
+++ b/ws2811.c
@@ -50,7 +50,6 @@
 
 #define BUS_TO_PHYS(x) ((x)&~0xC0000000)
 
-#define OSC_FREQ                                 19200000   // crystal frequency
 
 /* 3 colors, 8 bits per byte, 3 symbols per bit + 55uS low for reset signal */
 #define LED_RESET_uS                             55
@@ -265,12 +264,16 @@ static int setup_pwm(ws2811_t *ws2811)
     volatile cm_pwm_t *cm_pwm = device->cm_pwm;
     int maxcount = max_channel_led_count(ws2811);
     uint32_t freq = ws2811->freq;
+    // jimbotel: add osc_freq variable
+    uint32_t osc_freq;
     int32_t byte_count;
 
     stop_pwm(ws2811);
 
     // Setup the PWM Clock - Use OSC @ 19.2Mhz w/ 3 clocks/tick
-    cm_pwm->div = CM_PWM_DIV_PASSWD | CM_PWM_DIV_DIVI(OSC_FREQ / (3 * freq));
+    // jimbotel: obtain right value of osc_freq from board_info.c
+    osc_freq = get_osc_freq();
+    cm_pwm->div = CM_PWM_DIV_PASSWD | CM_PWM_DIV_DIVI(osc_freq / (3 * freq));
     cm_pwm->ctl = CM_PWM_CTL_PASSWD | CM_PWM_CTL_SRC_OSC;
     cm_pwm->ctl = CM_PWM_CTL_PASSWD | CM_PWM_CTL_SRC_OSC | CM_PWM_CTL_ENAB;
     usleep(10);


### PR DESCRIPTION
Added support for Rpi 4B.
Tested on a Rpi 4B with a single NeoPixel LED: https://www.adafruit.com/product/1734
It worked fine, but still interferes with the audio jack.
Thanks,
Jaime-